### PR TITLE
Install prometheus, thanos and stitch dashboards

### DIFF
--- a/.deployUtils
+++ b/.deployUtils
@@ -43,7 +43,7 @@ metadata:
   namespace: metallb-system
 spec:
   addresses:
-  - 172.31.${metalLBSubnet}.0/24
+  - 172.30.${metalLBSubnet}.0/24
 ---
 apiVersion: metallb.io/v1beta1
 kind: L2Advertisement
@@ -162,10 +162,10 @@ spec:
         cpu: "1000m"
         memory: "1500Mi"
   name: apicurio-studio
-  url: apicurio.172.31.0.2.nip.io
+  url: apicurio.172.30.0.2.nip.io
   keycloak:
     install: true
-    url: keycloak.apicurio.172.31.0.2.nip.io
+    url: keycloak.apicurio.172.30.0.2.nip.io
     realm: apicurio
     volumeSize: 1Gi
   database:
@@ -413,13 +413,28 @@ deployPrometheusForFederation() {
 }
 
 installAPIDashboards() {
+  local PROMETHEUS_FOR_FEDERATION_API_DASHBOARDS_KUSTOMIZATION_DIR="$2"
+  local PROMETHEUS_FOR_FEDERATION_API_DASHBOARDS_GRAFANA_PATCH="$3"
+  if [ -z "$2" ]; then
+    PROMETHEUS_FOR_FEDERATION_API_DASHBOARDS_KUSTOMIZATION_DIR=${LOCAL_SETUP_DIR}/../config/prometheus-for-federation/api-dashboards
+  fi
+  if [ -z "$3" ]; then
+    PROMETHEUS_FOR_FEDERATION_API_DASHBOARDS_GRAFANA_PATCH=${PROMETHEUS_FOR_FEDERATION_API_DASHBOARDS_KUSTOMIZATION_DIR}/grafana_deployment_patch.yaml
+  fi
   clusterName=${1}
   if [[ -n "${METRICS_FEDERATION}" ]]; then
     echo "Deploying API Dashboards in ${clusterName}"
     kubectl config use-context kind-${clusterName}
-    ${KUSTOMIZE_BIN} build ${PROMETHEUS_FOR_FEDERATION_KUSTOMIZATION_DIR}/api-dashboards | kubectl apply -f -
+    ${KUSTOMIZE_BIN} build ${PROMETHEUS_FOR_FEDERATION_API_DASHBOARDS_KUSTOMIZATION_DIR} | kubectl apply -f -
 
-    kubectl patch deployment grafana -n monitoring --type=json -p "$(cat ${PROMETHEUS_FOR_FEDERATION_KUSTOMIZATION_DIR}/api-dashboards/grafana_deployment_patch.yaml)"
+    if [[ ${PROMETHEUS_FOR_FEDERATION_API_DASHBOARDS_GRAFANA_PATCH} == https* ]]; then
+      echo "Fetching patch file from ${PROMETHEUS_FOR_FEDERATION_API_DASHBOARDS_GRAFANA_PATCH}"
+      curl -L -o ${TMP_DIR}/patch.yaml ${PROMETHEUS_FOR_FEDERATION_API_DASHBOARDS_GRAFANA_PATCH}
+      kubectl patch deployment grafana -n monitoring --type=json -p "$(cat ${TMP_DIR}/patch.yaml)"
+    else
+      echo "Using local file at ${PROMETHEUS_FOR_FEDERATION_API_DASHBOARDS_GRAFANA_PATCH}"
+      kubectl patch deployment grafana -n monitoring --type=json -p "$(cat ${PROMETHEUS_FOR_FEDERATION_API_DASHBOARDS_GRAFANA_PATCH})"
+    fi
     kubectl rollout restart deployment/grafana -n monitoring
   fi
 }

--- a/.kindUtils
+++ b/.kindUtils
@@ -72,7 +72,7 @@ setupClusters() {
     local dataPlaneClusterCount=$5
 
     # Create network for the clusters
-    docker network create -d bridge --subnet 172.31.0.0/16 ${KIND_CLUSTER_DOCKER_NETWORK} --gateway 172.31.0.1 \
+    docker network create -d bridge --subnet 172.30.0.0/16 ${KIND_CLUSTER_DOCKER_NETWORK} --gateway 172.30.0.1 \
       -o "com.docker.network.bridge.enable_ip_masquerade"="true" \
       -o "com.docker.network.driver.mtu"="1500"
 


### PR DESCRIPTION
closes #8 
closes #7 

I change the subnet to 172.30 to avoid overlap with mgc network.

API Dashboards are pulled in from api-upstream branch of mgc repo at this time.
Given that most other resources (all?) are pulled from that repo too at this time, I think we should defer changing that and do it in bulk at a later time.