### PR TITLE
Fix install of components into workload clusters

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -107,8 +107,8 @@ installAPIDashboards ${KIND_CLUSTER_CONTROL_PLANE} ${PROMETHEUS_FOR_FEDERATION_A
 deployApicurito ${KIND_CLUSTER_CONTROL_PLANE}
 
 
-if [[ -n "${MGC_WORKLOAD_CLUSTERS_COUNT}" ]]; then
-  for ((i = 1; i <= ${MGC_WORKLOAD_CLUSTERS_COUNT}; i++)); do
+if [[ -n "${API_WORKLOAD_CLUSTERS_COUNT}" ]]; then
+  for ((i = 1; i <= ${API_WORKLOAD_CLUSTERS_COUNT}; i++)); do
     deployQuickStartWorkload ${KIND_CLUSTER_WORKLOAD}-${i}
     configureMetalLB ${KIND_CLUSTER_WORKLOAD}-${i} $((${metalLBSubnetStart} + ${i}))
     deployOLM ${KIND_CLUSTER_WORKLOAD}-${i}


### PR DESCRIPTION
Things weren't being installed in  workload clusters.

After install, should have all these namespaces in each cluster and nothing crashing

```
$ kubectl --context kind-api-control-plane get ns
NAME                                     STATUS   AGE
apicurito                                Active   3m54s
cert-manager                             Active   6m19s
default                                  Active   8m12s
ingress-nginx                            Active   5m5s
kind-api-workload-1                      Active   47s
kuadrant-system                          Active   4m20s
kube-node-lease                          Active   8m13s
kube-public                              Active   8m13s
kube-system                              Active   8m13s
local-path-storage                       Active   8m9s
metallb-system                           Active   6m19s
monitoring                               Active   4m4s
multi-cluster-gateways                   Active   6m19s
multicluster-gateway-controller-system   Active   6m19s
open-cluster-management                  Active   7m36s
open-cluster-management-hub              Active   7m13s

$ kubectl --context kind-api-control-plane get po -A|grep -v Running | grep -v Completed
NAMESPACE                                NAME                                                       READY   STATUS      RESTARTS   AGE

$ kubectl --context kind-api-workload-1 get ns
NAME                                  STATUS   AGE
default                               Active   11m
istio-operator                        Active   7m26s
istio-system                          Active   7m26s
kuadrant-system                       Active   4m12s
kube-node-lease                       Active   11m
kube-public                           Active   11m
kube-system                           Active   11m
local-path-storage                    Active   11m
metallb-system                        Active   7m26s
monitoring                            Active   4m4s
olm                                   Active   6m9s
open-cluster-management               Active   4m59s
open-cluster-management-agent         Active   4m59s
open-cluster-management-agent-addon   Active   4m45s
operators                             Active   6m9s

$ kubectl --context kind-api-workload-1 get po -A|grep -v Running | grep -v Completed
NAMESPACE                       NAME                                                              READY   STATUS      RESTARTS        AGE

$ kubectl --context kind-api-workload-2 get ns
NAME                                  STATUS   AGE
default                               Active   11m
istio-operator                        Active   4m2s
istio-system                          Active   4m2s
kuadrant-system                       Active   39s
kube-node-lease                       Active   11m
kube-public                           Active   11m
kube-system                           Active   11m
local-path-storage                    Active   11m
metallb-system                        Active   4m2s
monitoring                            Active   34s
olm                                   Active   2m43s
open-cluster-management               Active   2m7s
open-cluster-management-agent         Active   2m7s
open-cluster-management-agent-addon   Active   78s
operators                             Active   2m43s

davidmartin at MacBook-Pro in ~/work/api-poc-petstore on main [$]
$ kubectl --context kind-api-workload-2 get po -A|grep -v Running | grep -v Completed
NAMESPACE                       NAME                                                              READY   STATUS      RESTARTS     AGE

```