### PR TITLE
Remove Gatekeeper from workloads and scale down controller to 1 repli…

### DIFF
--- a/.deployUtils
+++ b/.deployUtils
@@ -654,7 +654,7 @@ deployGatekeeper(){
   kubectl config use-context kind-${clusterName}
   echo "Deploying Gatekeeper in kind-${clusterName}"
   ${HELM_BIN} repo add gatekeeper https://open-policy-agent.github.io/gatekeeper/charts
-  ${HELM_BIN} install gatekeeper/gatekeeper --name-template=gatekeeper --namespace gatekeeper-system --create-namespace
+  ${HELM_BIN} install gatekeeper/gatekeeper --set replicas=1 --name-template=gatekeeper --namespace gatekeeper-system --create-namespace
   kubectl --context kind-${clusterName} wait --namespace=gatekeeper-system --for=condition=available --timeout=300s deployment/gatekeeper-audit
   kubectl --context kind-${clusterName} wait --namespace=gatekeeper-system --for=condition=available --timeout=300s deployment/gatekeeper-controller-manager
   echo "Gatekeeper Ready"

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -118,8 +118,6 @@ if [[ -n "${API_WORKLOAD_CLUSTERS_COUNT}" ]]; then
     configureManagedAddon ${KIND_CLUSTER_CONTROL_PLANE} ${KIND_CLUSTER_WORKLOAD}-${i}
     configureClusterAsIngress ${KIND_CLUSTER_CONTROL_PLANE} ${KIND_CLUSTER_WORKLOAD}-${i}
     deployPrometheusForFederation ${KIND_CLUSTER_WORKLOAD}-${i} ${PROMETHEUS_FOR_FEDERATION_DIR}?ref=${MGC_BRANCH}
-    deployGatekeeper ${KIND_CLUSTER_WORKLOAD}-${i}
-    configureGatekeeper ${KIND_CLUSTER_WORKLOAD}-${i}
   done
 fi
 


### PR DESCRIPTION
…ca in hub

Removing gatekeeper from the workloads (so only able to show the policy violations in hub, not the rate limits constraints in workloads),
and also scaling down 1 of the gatekeeper pods to 1 instead of 3 in the hub,
we're at this:

![image](https://github.com/Kuadrant/api-quickstart/assets/878251/320742c0-a39d-4b4f-bd11-1e30afd58f95)

it would be a base req. of 6 cpus and 9GB of memory