### PR TITLE
Readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ kubectl --context kind-api-workload-1 apply -f ./resources/ratelimitpolicy.yaml
 # Push this change back to your fork
 git add resources/ratelimitpolicy.yaml
 git commit -am "Generated RateLimitPolicy"
+git push # You may need to set an upstream as well
 ```
 
 Lastly, we'll generate a Gateway API `HTTPRoute` to service our APIs:
@@ -268,11 +269,12 @@ kuadrantctl generate gatewayapi httproute --oas openapi.yaml | yq -P
 kuadrantctl generate gatewayapi httproute --oas openapi.yaml | yq -P > resources/httproute.yaml
 
 # Apply this resource to our cluster, setting the hostname in via the KUADRANT_ZONE_ROOT_DOMAIN env var:
-cat ./resources/httproute.yaml | envsubst | kubectl --context kind-api-workload-1 apply -f -
+kustomize build ./resources/ | envsubst | kubectl --context kind-api-workload-1 apply -f-
 
 # Push this change back to your fork
 git add resources/httproute.yaml
 git commit -am "Generated HTTPRoute"
+git push # You may need to set an upstream as well
 ```
 
 ### Check our applied policies


### PR DESCRIPTION
* Some structural and heading changes to divide up the walkthrough more logically
* Removed steps for accessing the httproute early as it's not needed until later
* Fix some kuadrantctl generate cmds
* Add some missing git cmds
* Summary section at the end of walkthrough

Not included:
* DNS geosight piece
* Any verification beyond the "Check our applied policies" section as I couldn't reproduce the 429 at this point. Likely related to [RateLimitPolicy errors](https://gist.github.com/david-martin/5cbabd706c44e2d421f53568af2757a2) in the kuadrant operator logs. 