### PR TITLE
Adding pre-req check in quickstart script for gettext package

### DIFF
--- a/.deployUtils
+++ b/.deployUtils
@@ -10,6 +10,13 @@ then
         echo "Try 'brew install coreutils'"
     fi
     exit
+elif ! command -v envsubst &> /dev/null
+then
+    echo "'envsubst' command not found."
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        echo "Try 'brew install gettext'"
+    fi
+    exit
 fi
 
 wait_for() {


### PR DESCRIPTION
**WHAT**
Adding logic to quickstart script for handling the envsubst / gettext dependency on MacOS

**WHY**
While running the quickstart script I encountered the following error:
```
.deployUtils: line 531: envsubst: command not found
```
The fix was to install the gettext package via brew on MacOS